### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "scripts": {
         "test": "phpunit",
         "lint": "phpcs --standard=phpcs.ruleset.xml $(find ./ -name '*.php')",
-        "fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
+        "fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')",
+        "phpstan": "phpstan analyse --memory-limit=1G"
 
     },
     "minimum-stability": "stable",
@@ -26,7 +27,10 @@
     "require-dev": {
         "phpunit/phpunit": "^6|^7|^8|^9",
         "wp-coding-standards/wpcs": "^3.0",
-        "yoast/phpunit-polyfills": "^2.0"
+        "yoast/phpunit-polyfills": "^2.0",
+        "phpstan/phpstan": "^2.1",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/wordpress-stubs": "^6.9"
     },
     "autoload": {
         "psr-0": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,49 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to static method add_command\(\) on an unknown class WP_CLI\.$#'
+			identifier: class.notFound
+			count: 1
+			path: hagakure.php
+
+		-
+			message: '#^Found usage of constant DOING_CRON\. Use wp_doing_cron\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: src/Kunoichi/Hagakure/DbLogger.php
+
+		-
+			message: '#^Function str_contains not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: src/Kunoichi/Hagakure/DbLogger.php
+
+		-
+			message: '#^Offset ''file'' on array\{type\: 1\|16, message\: string, file\: string, line\: int\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: src/Kunoichi/Hagakure/DbLogger.php
+
+		-
+			message: '#^Offset ''message'' on array\{type\: 1\|16, message\: string, file\: string, line\: int\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: src/Kunoichi/Hagakure/DbLogger.php
+
+		-
+			message: '#^Found usage of constant DOING_CRON\. Use wp_doing_cron\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: src/Kunoichi/Hagakure/ErrorHandler.php
+
+		-
+			message: '#^Method Kunoichi\\Hagakure\\ErrorHandler\:\:hagakure_error_handler\(\) should return false but returns bool\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Kunoichi/Hagakure/ErrorHandler.php
+
+		-
+			message: '#^Found usage of constant DOING_CRON\. Use wp_doing_cron\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: src/Kunoichi/Hagakure/SlowQuery.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,12 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - hagakure.php
+        - src/
+    excludePaths:
+        analyseAndScan:
+            - src/Kunoichi/Hagakure/Command.php


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能
- `src/Kunoichi/Hagakure/Command.php` は WP_CLI_Command 依存のため解析対象から除外

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)