### PR TITLE
エラー抑制演算子(@)・error_reporting() を尊重する

### DIFF
--- a/src/Kunoichi/Hagakure/ErrorHandler.php
+++ b/src/Kunoichi/Hagakure/ErrorHandler.php
@@ -34,6 +34,12 @@ class ErrorHandler extends Singleton {
 	 * @return false
 	 */
 	public function hagakure_error_handler( $err_no, $err_str, $err_file = '', $err_line = 0 ) {
+		// Respect the error suppression operator(@) and error_reporting().
+		// PHP lowers error_reporting() while @ is active, so bail out and let
+		// the built-in handler (which also no-ops while suppressed) take over.
+		if ( ! ( error_reporting() & $err_no ) ) {
+			return false;
+		}
 		$stack  = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$prefix = 'PHP ';
 		$return = true;

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Test the error handler.
+ *
+ * @package hagakure
+ */
+
+/**
+ * Ensure the error handler respects the @ operator / error_reporting().
+ */
+class ErrorHandlerTest extends WP_UnitTestCase {
+
+	/**
+	 * Original error_log ini setting.
+	 *
+	 * @var string|false
+	 */
+	private $original_log;
+
+	/**
+	 * Path to the temporary log file.
+	 *
+	 * @var string
+	 */
+	private $log_file;
+
+	/**
+	 * Redirect error_log() output to a temporary file.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->log_file     = tempnam( sys_get_temp_dir(), 'hagakure-log-' );
+		$this->original_log = ini_get( 'error_log' );
+		ini_set( 'error_log', $this->log_file );
+	}
+
+	/**
+	 * Restore the error_log setting and remove the temporary file.
+	 */
+	public function tear_down() {
+		ini_set( 'error_log', false === $this->original_log ? '' : $this->original_log );
+		if ( file_exists( $this->log_file ) ) {
+			unlink( $this->log_file );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * The contents of the temporary log file.
+	 *
+	 * @return string
+	 */
+	private function log_contents() {
+		return file_exists( $this->log_file ) ? file_get_contents( $this->log_file ) : '';
+	}
+
+	/**
+	 * Errors suppressed with @ must not be logged.
+	 */
+	public function test_suppressed_error_is_ignored() {
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@trigger_error( 'hagakure-suppressed-warning', E_USER_WARNING );
+		$this->assertStringNotContainsString(
+			'hagakure-suppressed-warning',
+			$this->log_contents(),
+			'An error suppressed with the @ operator must not be logged.'
+		);
+	}
+
+	/**
+	 * Errors that are not suppressed must still be logged.
+	 */
+	public function test_visible_error_is_logged() {
+		trigger_error( 'hagakure-visible-warning', E_USER_WARNING );
+		$this->assertStringContainsString(
+			'hagakure-visible-warning',
+			$this->log_contents(),
+			'An error that is not suppressed must be logged.'
+		);
+	}
+}


### PR DESCRIPTION
## 概要

`ErrorHandler::hagakure_error_handler()` が `error_reporting()` の現在値を確認せず無条件にログ出力していたため、**`@` 演算子で明示的に抑制されたエラーまでログに出力されていた**問題を修正する。

`set_error_handler()` で登録したカスタムハンドラは `@` を付けても呼び出されるが、PHPは `@` が有効な間 `error_reporting()` の戻り値を下げる。ハンドラ冒頭でこれを確認することで、抑制対象のエラーを判別できる（PHPマニュアル記載の定番イディオム）。

## 実害の例

`socket_read()` などブロッキング系関数では、シグナル割り込みにより `EINTR` の警告が発生し、呼び出し側は `@socket_read()` のように意図的に抑制する。Hagakure有効時はこの `@` が無効化され、不要な `EINTR` 警告がPHPエラーログに垂れ流しになっていた。

## 変更内容

- `hagakure_error_handler()` 冒頭に `if ( ! ( error_reporting() & $err_no ) ) { return false; }` を追加
- `tests/ErrorHandlerTest.php` を追加し、`@` 抑制した警告がログに出ない／抑制していない警告は出ることを検証

## 挙動確認

- PHP 7.x 以前: `@` 中は `error_reporting()` が `0` → 抑制
- PHP 8.0 以降: `@` 中は `E_ERROR | ...`（`E_WARNING` 非含有）→ 抑制
- `return false` 後はPHP組み込みハンドラに渡るが、抑制状態のため出力されない

## テスト

- PHPUnit: 4/4 pass（修正を外すと新規テストが失敗することを確認済み）
- PHPCS / PHPStan: clean

Fix #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)