### PR TITLE
READMEメタデータ整備・SECURITY.md・PHPマトリクス拡張

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     name: PHP UnitTest
     strategy:
       matrix:
-        php: [ '7.4', '8.0' ]
+        php: [ '7.4', '8.0', '8.2', '8.3' ]
         wp: [ 'latest', '6.6' ]
     uses: tarosky/workflows/.github/workflows/wp-unit-test.yml@main
     with:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Hagakure - Yet Another Error Reporter
 
 Contributors: tarosky, Takahashi_Fumiki, kuno1  
-Tags: php, error, recovery
-Tested up to: 6.6  
+Tags: error, debug, error-log, backtrace, slow-query  
+Requires at least: 5.9  
+Tested up to: 7.0  
+Requires PHP: 7.4  
 Stable Tag: nightly  
 License: GPLv3 or later  
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -11,7 +13,7 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 A WordPress plugin to clarify meaningless errors like "Allowed memory size of xxxxxxxx bytes exhausted".
 
 <!-- only:github/ -->
-![Master Workflow](https://github.com/tarosky/hagakure/actions/workflows/wordpress.yml/badge.svg)
+![Test Workflow](https://github.com/tarosky/hagakure/actions/workflows/test.yml/badge.svg)
 <!-- /only:github -->
 
 ## Description
@@ -65,11 +67,22 @@ The base text for dummy content is "Three Ghost Story" by Charles Dickens. The t
 
 ## Installation
 
+### Requirements
+
+* WordPress 5.9 or later.
+* PHP 7.4 or later. Tested and supported on PHP 7.4, 8.0, 8.2 and 8.3.
+
+### Steps
+
 1. Upload `hagakure` folder to the `/wp-content/plugins` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 3. That's it. This plugin will work as background.
 
 ## Frequently Asked Questions
+
+### Does this plugin support PHP 8.x?
+
+Yes. Hagakure requires PHP 7.4 or later and is tested against PHP 7.4, 8.0, 8.2 and 8.3 in CI.
 
 ### How can I contribute?
 
@@ -80,6 +93,14 @@ We host this plugin on GitHub [tarosky/hagakure](https://github.com/tarosky/haga
 W.I.P
 
 ## Changelog
+
+### 1.3.3
+
+* Respect the error suppression operator(@) and `error_reporting()` so that intentionally suppressed errors (e.g. `EINTR` from blocking socket functions) are no longer logged.
+
+### 1.3.2
+
+* Display only the request URI for non-DB errors in the error log.
 
 ### 1.3.1
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Hagakure is distributed as a rolling release on WordPress.org. Only the latest
+released version receives security updates. Please make sure you are running the
+most recent version before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through one of the following channels:
+
+1. **GitHub Security Advisories (preferred)** — Use the
+   ["Report a vulnerability"](https://github.com/tarosky/hagakure/security/advisories/new)
+   button on this repository's *Security* tab.
+2. **Contact TAROSKY** — If you cannot use GitHub, reach out via
+   [https://tarosky.co.jp/](https://tarosky.co.jp/).
+
+When reporting, please include as much of the following as possible:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof of concept.
+- Affected versions and your environment (WordPress / PHP version).
+
+We will acknowledge your report as soon as possible, keep you informed of the
+progress toward a fix, and credit you in the release notes unless you prefer to
+remain anonymous.

--- a/hagakure.php
+++ b/hagakure.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plugin Name: Hagakure - Yet Another Error Reporter
+ * Plugin URI: https://github.com/tarosky/hagakure
  * Version: nightly
  * Description: A WordPress plugin to clarify meaningless errors like "Allowed memory size of xxxxxxxx bytes exhausted".
  * Author: Tarosky


### PR DESCRIPTION
新バージョンに向けたメタデータ整備とリポジトリ衛生の改善。AIトリアージ系イシューのうち、コード/リポジトリで完結するものをまとめて解消する。

## 変更内容

### README.md
- **Tags**: `php, error, recovery`（3個）→ `error, debug, error-log, backtrace, slow-query`（5個）に拡充 (#39)
- **Tested up to**: 6.6 → 7.0 に更新（wp-env の WP 7.0 でテスト通過確認済み）(#32)
- **Requires at least / Requires PHP** をヘッダに明記
- 壊れていたCIバッジ（存在しない `wordpress.yml` 参照）を `test.yml` に修正
- changelog に **1.3.2** を backfill、**1.3.3**（@演算子尊重の修正）を追加 (#37)
- Installation に Requirements、FAQ に PHP 8.x 対応を明記 (#34)

### hagakure.php
- `Plugin URI` ヘッダを追加（公式リポジトリへの導線）(#40)

### SECURITY.md（新規）
- GitHub Security Advisories 経由の脆弱性報告窓口を整備 (#44)

### .github/workflows/test.yml
- PHP マトリクスに **8.2 / 8.3** を追加（従来は 7.4 / 8.0 のみ）。README の「PHP 8.x 対応」記述を実態と一致させ、#42 の正当な指摘（8.3 での動作未検証）も解消する。

## 補足
- `Requires at least` の最低WPバージョン引き上げ（5.9→6.6）は利用者影響があるため本PRでは見送り（別途判断）。
- スクリーンショット(#38)・レビュー/インストール数(#43/#35) は画像やマーケ施策が必要なため対象外。

Closes #44
Closes #37
Closes #39
Closes #40
Closes #34
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)