### PR TITLE
アセット更新ラッパーを追加（共有ワークフロー方式）

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -1,0 +1,11 @@
+name: Update WordPress.org assets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    uses: tarosky/workflows/.github/workflows/asset-update.yml@main
+    with:
+      slug: ${{ github.event.repository.name }}
+    secrets: inherit


### PR DESCRIPTION
## 概要

WordPress.org のアセット（アイコン・バナー）をリリースと独立して反映するための薄いラッパーを追加する。共有 reusable workflow (`tarosky/workflows/.github/workflows/asset-update.yml`) を `workflow_dispatch` で呼び出すだけ。

## 背景・方針

Org 全体でアセット反映を共有ワークフロー方式に一本化した（tarosky/workflows#121, #122）。共有ワークフローは自前の assets-only SVN commit を採用しており、trunk / readme.txt には一切触れないため、`workflow_dispatch` をいつ実行しても未リリース README が漏れることはない。

Refs tarosky/workflows#121
